### PR TITLE
main: dist/lrz.all.bundle.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "lrz",
-  "version": "4.9.36",
+  "version": "4.9.37",
   "description": "前端本地客户端压缩图片，兼容IOS，Android，PC、自动按需加载文件",
-  "main": "dist/lrz.bundle.js",
+  "main": "dist/lrz.all.bundle.js",
   "scripts": {
     "test": "node ./node_modules/karma/bin/karma start"
   },


### PR DESCRIPTION
webpack 直接 `require('lrz')` 在移动端会报错，因为 webpack 不会将 1.chunk.js 2.chunk.js 打包。