### PR TITLE
修复iOS版本号获取为NaN的问题

### DIFF
--- a/lrz.all.bundle.js
+++ b/lrz.all.bundle.js
@@ -2505,7 +2505,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 	var UA = (function (userAgent) {
-	    var ISOldIOS     = /OS (.*) like Mac OS X/g.exec(userAgent),
+	    var ISOldIOS     = /OS (\d+(?:_\d)?)(?:_\d)* like Mac OS X/g.exec(userAgent),
 	        isOldAndroid = /Android (\d.*?);/g.exec(userAgent) || /Android\/(\d.*?) /g.exec(userAgent);
 
 	    // 判断设备是否是IOS7以下

--- a/lrz.bundle.js
+++ b/lrz.bundle.js
@@ -117,7 +117,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 	var UA = (function (userAgent) {
-	    var ISOldIOS     = /OS (.*) like Mac OS X/g.exec(userAgent),
+	    var ISOldIOS     = /OS (\d+(?:_\d)?)(?:_\d)* like Mac OS X/g.exec(userAgent),
 	        isOldAndroid = /Android (\d.*?);/g.exec(userAgent) || /Android\/(\d.*?) /g.exec(userAgent);
 
 	    // 判断设备是否是IOS7以下

--- a/src/lrz.js
+++ b/src/lrz.js
@@ -8,7 +8,7 @@ var Promise          = require('Promise'),
 
 
 var UA = (function (userAgent) {
-    var ISOldIOS     = /OS (.*) like Mac OS X/g.exec(userAgent),
+    var ISOldIOS     = /OS (\d+(?:_\d)?)(?:_\d)* like Mac OS X/g.exec(userAgent),
         isOldAndroid = /Android (\d.*?);/g.exec(userAgent) || /Android\/(\d.*?) /g.exec(userAgent);
 
     // 判断设备是否是IOS7以下


### PR DESCRIPTION
当版本号为`"13_4_1"`时，用`+"13_4_1"`转换为数字会得到NaN

**没有打包到dist**